### PR TITLE
Enable tablet mode

### DIFF
--- a/rpi4/device.mk
+++ b/rpi4/device.mk
@@ -41,5 +41,7 @@ PRODUCT_COPY_FILES += \
 PRODUCT_VENDOR_PROPERTIES +=    \
     ro.hardware.vulkan=broadcom \
 
+PRODUCT_CHARACTERISTICS := tablet
+
 # It is the only way to set ro.hwui.use_vulkan=true
 #TARGET_USES_VULKAN = true


### PR DESCRIPTION
This is a simple PR that switches the Tesla Android system from phone mode to tablet mode, which is slightly more accessible on a big touchscreen like the one in Tesla vehicles.